### PR TITLE
fix: get number from query params not from body

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -38,18 +38,9 @@ def get_fun_fact(n):
 
 @app.route('/api/classify-number', methods=['GET'])
 def classify_number():
-    # Ensure the request has JSON data
-    if not request.is_json:
-        return jsonify({"error": "Request must be JSON"}), 400
 
-    # Get JSON data from the request
-    data = request.get_json()
-
-    # Check if 'number' is present in the JSON payload
-    if 'number' not in data:
-        return jsonify({"error": "Missing 'number' in JSON payload"}), 400
-
-    number = data['number']
+    # get number from query params
+    number =int(request.args["number"])
 
     # Validate that the input is a valid integer
     if not isinstance(number, int):


### PR DESCRIPTION
the number should be gotten from query params not from the body. cors probably still need to be implemented. Right now , your error response are too verbose.
the question was specific about ehat an error 400 response should return. I think you should be rigid about that.
also maybe add a check if the int wrapping does not actually provide a int type for number.
```json
{
  "number": "alphabet"
  "error": true
}
```
